### PR TITLE
Fix spoiler links on mobile

### DIFF
--- a/gulp/res/css/style.css
+++ b/gulp/res/css/style.css
@@ -1672,7 +1672,10 @@ row.wrap.sb .col {
 	#filter-value-input {
 		width: 100%;
 	}
-
+	
+	 .spoiler a {
+    		color: white !important;
+  	}
 }
 
 


### PR DESCRIPTION
Links behind a spoiler become always visible on mobile devices since to reveal the spoiler content users usually touch it (instead of holding it) which has the side effect of interacting with unknown links accidentally.